### PR TITLE
Fixed 'ref' type for Typescript definitions.

### DIFF
--- a/react-konva.d.ts
+++ b/react-konva.d.ts
@@ -25,20 +25,24 @@ export interface KonvaNodeProps {
   onTransformEnd?(evt: any): void;
 }
 
-export class KonvaNodeComponent<
+export interface KonvaNodeComponent<
   Node extends Konva.Node,
   Props = Konva.NodeConfig
-> extends React.Component<Props & KonvaNodeProps> {
+  // We use React.ClassAttributes to fake the 'ref' attribute. This will ensure
+  // consumers get the proper 'Node' type in 'ref' instead of the wrapper
+  // component type.
+> extends React.SFC<Props & KonvaNodeProps & React.ClassAttributes<Node>> {
   getPublicInstance(): Node;
   getNativeNode(): Node;
   // putEventListener(type: string, listener: Function): void;
   // handleEvent(event: Event): void;
 }
 
-export class KonvaContainerComponent<
+export interface KonvaContainerComponent<
   Container extends Konva.Container,
   Props = Konva.ContainerConfig
-> extends React.Component<Props & KonvaNodeProps> {
+  // See comment inside KonvaNodeComponent if modifiying next line.
+> extends React.SFC<Props & KonvaNodeProps & React.ClassAttributes<Node>> {
   // moveChild(prevChild, lastPlacedNode, nextIndex, lastIndex): void;
   // createChild(child, afterNode, mountImage): void;
   // removeChild(child, node): void;
@@ -70,54 +74,62 @@ export interface StageProps
   onContentWheel?(evt: any): void;
 }
 
+// Stage is the only real class because the others are stubs that only know how
+// to be rendered when they are under stage. Since there is no real backing
+// class and are in reality are a string literal we don't want users to actually
+// try and use them as a type. By defining them as a variable with an interface
+// consumers will not be able to use the values as a type or constructor.
+// The down side to this approach, is that typescript thinks the type is a
+// function, but if the user tries to call it a runtime exception will occur.
+
 /** Stage */
-export class Stage extends KonvaContainerComponent<Konva.Stage, StageProps> {
+export class Stage extends React.Component<StageProps & KonvaNodeProps> {
   getStage(): Konva.Stage;
 }
 
 /** Containers */
-export class Layer extends KonvaContainerComponent<
+export var Layer: KonvaContainerComponent<
   Konva.Layer,
   Konva.LayerConfig
 > {}
-export class FastLayer extends KonvaContainerComponent<
+export var FastLayer: KonvaContainerComponent<
   Konva.FastLayer,
   Konva.LayerConfig
 > {}
-export class Group extends KonvaContainerComponent<Konva.Group> {}
-export class Label extends KonvaContainerComponent<Konva.Label> {}
+export var Group: KonvaContainerComponent<Konva.Group> {}
+export var Label: KonvaContainerComponent<Konva.Label> {}
 
 /** Shapes */
-export class Rect extends KonvaNodeComponent<Konva.Rect, Konva.RectConfig> {}
-export class Circle extends KonvaNodeComponent<
+export var Rect: KonvaNodeComponent<Konva.Rect, Konva.RectConfig>;
+export var Circle: KonvaNodeComponent<
   Konva.Circle,
   Konva.CircleConfig
-> {}
-export class Ellipse extends KonvaNodeComponent<
+>;
+export var Ellipse: KonvaNodeComponent<
   Konva.Ellipse,
   Konva.EllipseConfig
-> {}
-export class Wedge extends KonvaNodeComponent<Konva.Wedge, Konva.WedgeConfig> {}
-export class Transformer extends KonvaNodeComponent<Konva.Transformer, Konva.TransformerConfig> {}
-export class Line extends KonvaNodeComponent<Konva.Line, Konva.LineConfig> {}
-export class Sprite extends KonvaNodeComponent<
+>;
+export var Wedge: KonvaNodeComponent<Konva.Wedge, Konva.WedgeConfig>;
+export var Transformer: KonvaNodeComponent<Konva.Transformer, Konva.TransformerConfig>;
+export var Line: KonvaNodeComponent<Konva.Line, Konva.LineConfig>;
+export var Sprite: KonvaNodeComponent<
   Konva.Sprite,
   Konva.SpriteConfig
-> {}
-export class Image extends KonvaNodeComponent<Konva.Image, Konva.ImageConfig> {}
-export class Text extends KonvaNodeComponent<Konva.Text, Konva.TextConfig> {}
-export class TextPath extends KonvaNodeComponent<
+>;
+export var Image: KonvaNodeComponent<Konva.Image, Konva.ImageConfig>;
+export var Text: KonvaNodeComponent<Konva.Text, Konva.TextConfig>;
+export var TextPath: KonvaNodeComponent<
   Konva.TextPath,
   Konva.TextPathConfig
-> {}
-export class Star extends KonvaNodeComponent<Konva.Star, Konva.StarConfig> {}
-export class Ring extends KonvaNodeComponent<Konva.Ring, Konva.RingConfig> {}
-export class Arc extends KonvaNodeComponent<Konva.Arc, Konva.ArcConfig> {}
-export class Tag extends KonvaNodeComponent<Konva.Tag, Konva.TagConfig> {}
-export class Path extends KonvaNodeComponent<Konva.Path, Konva.PathConfig> {}
-export class RegularPolygon extends KonvaNodeComponent<
+>;
+export var Star: KonvaNodeComponent<Konva.Star, Konva.StarConfig>;
+export var Ring: KonvaNodeComponent<Konva.Ring, Konva.RingConfig>;
+export var Arc: KonvaNodeComponent<Konva.Arc, Konva.ArcConfig>;
+export var Tag: KonvaNodeComponent<Konva.Tag, Konva.TagConfig>;
+export var Path: KonvaNodeComponent<Konva.Path, Konva.PathConfig>;
+export var RegularPolygon: KonvaNodeComponent<
   Konva.RegularPolygon,
   Konva.RegularPolygonConfig
-> {}
-export class Arrow extends KonvaNodeComponent<Konva.Arrow, Konva.ArrowConfig> {}
-export class Shape extends KonvaNodeComponent<Konva.Shape, Konva.ShapeConfig> {}
+>;
+export var Arrow: KonvaNodeComponent<Konva.Arrow, Konva.ArrowConfig>;
+export var Shape: KonvaNodeComponent<Konva.Shape, Konva.ShapeConfig>;


### PR DESCRIPTION
Adds proper 'ref' type for nodes. Currently react's typing has the callback of 'ref' set to the component class, however at runtime it's actually the Konva node. This patch changes to use interfaces instead of classes and changes the component type to stateless components to accomplish this.

Sample code to test: 

```tsx
import * as Konva from 'konva';
import * as React from 'react';
import { render } from 'react-dom';
import { Layer, Rect, Stage, Text } from './react-konva';

class ColoredRect extends React.Component {
  private ref_ = React.createRef<Konva.Rect>();
  public state = {
    color: 'green'
  };

  public handleClick = () => {
    this.setState({
      color: Konva.Util.getRandomColor()
    });
    console.log(this.ref_);
  };

  public render() {
    // ensure it works with jsx style.
    return (
      <Rect
        ref={this.ref_}
        x={20}
        y={20}
        width={50}
        height={50}
        fill={this.state.color}
        shadowBlur={5}
        onClick={this.handleClick}
      />);
    // ensure it works with createElement
    return React.createElement(Rect, {
      ref: this.ref_,
      x: 20,
      y: 20,
      width: 50,
      height: 50,
      fill: this.state.color,
      shadowBlur: 5,
      onClick: this.handleClick,
    });
  }
}

class App extends React.Component {
  public render() {
    return (
      <Stage width={window.innerWidth} height={window.innerHeight}>
        <Layer>
          <Text text="Try click on rect" />
          <ColoredRect />
        </Layer>
      </Stage>
    );
  }
}

render(<App />, document.getElementById('root'));
```