### PR TITLE
Deep Equal check for props of type object

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "git@github.com:konvajs/react-konva.git"
   },
   "dependencies": {
+    "lodash": "^4.17.21",
     "react-reconciler": "~0.26.2",
     "scheduler": "^0.20.2"
   },

--- a/src/ReactKonvaCore.js
+++ b/src/ReactKonvaCore.js
@@ -118,3 +118,4 @@ export const Stage = React.forwardRef((props, ref) => {
 });
 
 export const useStrictMode = toggleStrictMode;
+export const useDeepEqualMode = false; 

--- a/src/makeUpdates.js
+++ b/src/makeUpdates.js
@@ -1,4 +1,6 @@
-import { Konva } from 'konva/lib/Global';
+import { Konva } from "konva/lib/Global";
+import deepEqual from "lodash/isEqual";
+import { useDeepEqualMode } from "./ReactKonvaCore";
 
 const propsToSkip = {
   children: true,
@@ -13,7 +15,7 @@ const propsToSkip = {
 let zIndexWarningShowed = false;
 let dragWarningShowed = false;
 
-export const EVENTS_NAMESPACE = '.react-konva-event';
+export const EVENTS_NAMESPACE = ".react-konva-event";
 
 let useStrictMode = false;
 export function toggleStrictMode(value) {
@@ -35,10 +37,10 @@ const EMPTY_PROPS = {};
 
 export function applyNodeProps(instance, props, oldProps = EMPTY_PROPS) {
   if (props === oldProps) {
-    console.error('same props');
+    console.error("same props");
   }
   // don't use zIndex in react-konva
-  if (!zIndexWarningShowed && 'zIndex' in props) {
+  if (!zIndexWarningShowed && "zIndex" in props) {
     console.warn(Z_INDEX_WARNING);
     zIndexWarningShowed = true;
   }
@@ -60,17 +62,14 @@ export function applyNodeProps(instance, props, oldProps = EMPTY_PROPS) {
     if (propsToSkip[key]) {
       continue;
     }
-    var isEvent = key.slice(0, 2) === 'on';
+    var isEvent = key.slice(0, 2) === "on";
     var propChanged = oldProps[key] !== props[key];
 
     // if that is a changed event, we need to remvoe it
     if (isEvent && propChanged) {
       var eventName = key.substr(2).toLowerCase();
-      if (eventName.substr(0, 7) === 'content') {
-        eventName =
-          'content' +
-          eventName.substr(7, 1).toUpperCase() +
-          eventName.substr(8);
+      if (eventName.substr(0, 7) === "content") {
+        eventName = "content" + eventName.substr(7, 1).toUpperCase() + eventName.substr(8);
       }
       instance.off(eventName, oldProps[key]);
     }
@@ -90,28 +89,28 @@ export function applyNodeProps(instance, props, oldProps = EMPTY_PROPS) {
     if (propsToSkip[key]) {
       continue;
     }
-    var isEvent = key.slice(0, 2) === 'on';
+    var isEvent = key.slice(0, 2) === "on";
     var toAdd = oldProps[key] !== props[key];
     if (isEvent && toAdd) {
       var eventName = key.substr(2).toLowerCase();
-      if (eventName.substr(0, 7) === 'content') {
-        eventName =
-          'content' +
-          eventName.substr(7, 1).toUpperCase() +
-          eventName.substr(8);
+      if (eventName.substr(0, 7) === "content") {
+        eventName = "content" + eventName.substr(7, 1).toUpperCase() + eventName.substr(8);
       }
       // check that event is not undefined
       if (props[key]) {
         newEvents[eventName] = props[key];
       }
     }
-    if (
-      !isEvent &&
-      (props[key] !== oldProps[key] ||
-        (strictUpdate && props[key] !== instance.getAttr(key)))
-    ) {
+    if (!isEvent && (props[key] !== oldProps[key] || (strictUpdate && props[key] !== instance.getAttr(key)))) {
+
+      const useDeepEqu = props._useDeepEqualMode || useDeepEqualMode;
+      if (!useDeepEqu || typeof props[key] !== "object" || 
+        !deepEqual(props[key], oldProps[key]) ||
+        !deepEqual(props[key], instance.getAttr(key))
+      ) {
       hasUpdates = true;
       updatedProps[key] = props[key];
+      }
     }
   }
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -7,6 +7,7 @@ import {
   Rect,
   Group,
   Image,
+  Line,
   useStrictMode,
   Text,
   __matchRectVersion,
@@ -207,6 +208,14 @@ describe('Test props setting', function () {
               ref={(node) => (this.rect = node)}
               {...this.props.rectProps}
             />
+
+          </Layer>
+          <Layer ref={(node) => (this.layer2 = node)}>
+            <Line
+              x={0} y={0} points={[10, 20, 30, 50]} stroke="red"
+              ref={(node) => (this.line = node)}
+              {...this.props.lineProps}
+            />
           </Layer>
         </Stage>
       );
@@ -241,14 +250,14 @@ describe('Test props setting', function () {
     const rect = instance.rect;
     // set new props
     const props1 = {
-      onClick: () => {},
+      onClick: () => { },
     };
     wrapper.setProps({ rectProps: props1 });
     expect(rect.eventListeners.click.length).to.equal(1);
     expect(rect.eventListeners.click[0].handler).to.equal(props1.onClick);
 
     const props2 = {
-      onClick: () => {},
+      onClick: () => { },
     };
     wrapper.setProps({ rectProps: props2 });
     expect(rect.eventListeners.click.length).to.equal(1);
@@ -354,6 +363,29 @@ describe('Test props setting', function () {
     });
     expect(rect.x()).to.equal(10);
   });
+
+  it('Shapes with deep-equal object propertys (e.g. points) shall not be updated', () => {
+    const line = instance.line;
+    wrapper.setProps({ lineProps: { _useDeepEqualMode: true } })
+    const layer = instance.layer; // layer with rect, supposed to be update 2 times 
+    const layer2 = instance.layer2; // layer with static line (but ref of points prop changed) should not be updated
+    sinon.spy(layer, 'batchDraw');
+    sinon.spy(layer2, 'batchDraw');
+    wrapper.setProps({
+      rectProps: {
+        fill: 'blue',
+      },
+    });
+    wrapper.setProps({
+      rectProps: {
+        fill: 'orange',
+      },
+    });
+    const batchdrawsLayer1 = layer.batchDraw.callCount;
+    const batchdrawsLayer2 = layer2.batchDraw.callCount;
+    expect(batchdrawsLayer1).to.equal(2);
+    expect(batchdrawsLayer2).to.equal(0);
+  })
 });
 
 describe('test lifecycle methods', () => {
@@ -644,10 +676,10 @@ describe('test reconciler', () => {
       render() {
         const kids = this.props.drawMany
           ? [
-              <Rect key="1" name="rect1" />,
-              <Rect key="2" name="rect2" />,
-              <Rect key="3" name="rect3" />,
-            ]
+            <Rect key="1" name="rect1" />,
+            <Rect key="2" name="rect2" />,
+            <Rect key="3" name="rect3" />,
+          ]
           : [<Rect key="1" name="rect1" />, <Rect key="3" name="rect3" />];
         return (
           <Stage ref={(node) => (this.stage = node)} width={300} height={300}>


### PR DESCRIPTION
Shapes with object props (like `<Line/>` using points=[...]) will always be updated when the object reference changes. 
For objects defined inside a react component (except you memoize it) that happens at every render iteration. 

Let's consider a simple example: 

```javascript
<Stage width={300} height={300}>
  <Layer>
    <Rect x={somePositionState}/>
  </Layer>
  <Layer>
    <Line // supposed to be static 
      x={0} y={0} points={[10, 20, 30, 50]} stroke="red"/>
  </Layer>
</Stage>
``` 
In this example the `<Rect>` is the only element supposed to update.  
The `<Line/>` in 2nd `<Layer/>` is always updated, too since  [10, 20, 30, 50] !== [10, 20, 30, 50]. 

To avoid these rerenders: 
- one could define the points prop outside of a react component (unconvenient)
- one could memoize points using React.useMemo(unconvenient too)
- one could check props of type object for deep-equality. 


The proposed PR provides an approach to implement deep-equality check 
- using lodash's isEqual() in makeUpdates.js, 
- to enable the deepEqual check mode 
  - global definition of useDeepEqualMode=true (ReactKonvaCore.js)
  - provide _useDeepEqualMode prop for shapes individually (makeUpdates.js)  
- To demonstrate the difference you can check  the test "Shapes with deep-equal object propertys (e.g. points) shall not be updated"
  -> the test will fail if you dismiss the `wrapper.setProps({ lineProps: { _useDeepEqualMode: true } })` line

PS: great library :+1: :smiley:


