### PR TITLE
Expose react reconciler

### DIFF
--- a/ReactKonvaCore.d.ts
+++ b/ReactKonvaCore.d.ts
@@ -1,5 +1,6 @@
 // special file for minimal import
 import * as React from 'react';
+import * as ReactReconciler from 'react-reconciler'
 import Konva from 'konva';
 
 export interface KonvaNodeEvents {
@@ -89,3 +90,4 @@ export var Arrow: KonvaNodeComponent<Konva.Arrow, Konva.ArrowConfig>;
 export var Shape: KonvaNodeComponent<Konva.Shape, Konva.ShapeConfig>;
 
 export var useStrictMode: (useStrictMode: boolean) => void;
+export var KonvaRenderer: ReactReconciler.Reconciler<any, any, any, any, any>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "git@github.com:konvajs/react-konva.git"
   },
   "dependencies": {
+    "@types/react-reconciler": "~0.26.2",
     "react-reconciler": "~0.26.2",
     "scheduler": "^0.20.2"
   },

--- a/src/ReactKonvaCore.js
+++ b/src/ReactKonvaCore.js
@@ -104,7 +104,7 @@ export const Arrow = 'Arrow';
 export const Shape = 'Shape';
 export const Transformer = 'Transformer';
 
-const KonvaRenderer = ReactFiberReconciler(HostConfig);
+export const KonvaRenderer = ReactFiberReconciler(HostConfig);
 
 KonvaRenderer.injectIntoDevTools({
   findHostInstanceByFiber: () => null,


### PR DESCRIPTION
https://github.com/pmndrs/zustand/issues/302#issuecomment-777659807

Might be helpful with resolving zombie child problem.

I have deployed this modification to my app. [neka.cc](https://www.neka.cc)

It helps ensure some imperative code like `node.cache()` that was nested in `useEffect` to be executed in the same order that was declared by JSX.