### PR TITLE
Make type definitions compatible with @types/react 18.0.0

### DIFF
--- a/ReactKonvaCore.d.ts
+++ b/ReactKonvaCore.d.ts
@@ -34,7 +34,7 @@ export interface KonvaNodeComponent<
   // We use React.ClassAttributes to fake the 'ref' attribute. This will ensure
   // consumers get the proper 'Node' type in 'ref' instead of the wrapper
   // component type.
-> extends React.SFC<Props & KonvaNodeEvents & React.ClassAttributes<Node>> {
+> extends React.FC<Props & KonvaNodeEvents & React.ClassAttributes<Node>> {
   getPublicInstance(): Node;
   getNativeNode(): Node;
   // putEventListener(type: string, listener: Function): void;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-dom": ">=16.8.0"
   },
   "devDependencies": {
-    "@types/react": "17.0.6",
+    "@types/react": "^17.0.6 || ^18.0.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.1",
     "chai": "4.3.4",
     "enzyme": "3.11.0",


### PR DESCRIPTION
* React.SFC has been removed from @types/react 18.0.0 => replaced with React.FC