### PR TITLE
Fix CommonJS build

### DIFF
--- a/nwb.config.cjs.js
+++ b/nwb.config.cjs.js
@@ -1,0 +1,39 @@
+const path = require("path");
+module.exports = {
+  type: "react-component",
+  npm: {
+    esModules: false,
+    umd: false,
+    cjs: true,
+  },
+  // may be useful for debugging tests
+  karma: {
+    browsers: ["ChromeHeadless"],
+    // browsers: ['Chrome'],
+  },
+  babel: {
+    plugins: [
+      [
+        // For CommonJS build we need to use the konva/cmj import path so that NodeJS 
+        // doesn't complain about a CommonJS file requiring a ES6 Module (Konva) 
+        "import-path-replace",
+        {
+          rules: [
+            // require('konva') -> require('konva/cmj')
+            {
+              match: "konva",
+              replacement: "konva/cmj",
+            },
+            // We need to replace the previous replacement here so there are two steps
+            // require('konva/lib/Core) -> require('konva/cmj/lib/Core')
+            // require('konva/cmj/lib/Core') -> require('konva/cmj/Core')
+            {
+              match: "konva/cmj/lib",
+              replacement: "konva/cmj",
+            },
+          ],
+        },
+      ],
+    ],
+  },
+};

--- a/nwb.config.cjs.js
+++ b/nwb.config.cjs.js
@@ -1,4 +1,4 @@
-const path = require("path");
+// CommonJS build configuration
 module.exports = {
   type: "react-component",
   npm: {

--- a/nwb.config.es.js
+++ b/nwb.config.es.js
@@ -1,12 +1,14 @@
+const path = require("path");
 module.exports = {
-  type: 'react-component',
+  type: "react-component",
   npm: {
     esModules: true,
     umd: false,
+    cjs: false
   },
   // may be useful for debugging tests
   karma: {
-    browsers: ['ChromeHeadless'],
+    browsers: ["ChromeHeadless"],
     // browsers: ['Chrome'],
   },
 };

--- a/nwb.config.js
+++ b/nwb.config.js
@@ -1,4 +1,4 @@
-const path = require("path");
+// ES6 build configuration
 module.exports = {
   type: "react-component",
   npm: {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "scripts": {
     "build": "npm run build-libs && cp ./ReactKonvaCore.d.ts ./lib && cp ./ReactKonvaCore.d.ts ./es",
     "build-cjs": "nwb --config ./nwb.config.cjs.js build-react-component",
-    "build-es": "nwb --config ./nwb.config.es.js build-react-component",
+    "build-es": "nwb --config ./nwb.config.js build-react-component",
     "build-libs": "npm run build-cjs && mv lib lib.back && npm run build-es && mv lib.back lib",
     "clean": "nwb clean-module && nwb clean-demo",
     "start": "nwb serve-react-demo",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/react": "^17.0.6 || ^18.0.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.1",
+    "babel-plugin-import-path-replace": "^0.1.0",
     "chai": "4.3.4",
     "enzyme": "3.11.0",
     "konva": "^8.0.1",
@@ -54,7 +55,10 @@
     "use-image": "^1.0.7"
   },
   "scripts": {
-    "build": "nwb build-react-component && cp ./ReactKonvaCore.d.ts ./lib && cp ./ReactKonvaCore.d.ts ./es",
+    "build": "npm run build-libs && cp ./ReactKonvaCore.d.ts ./lib && cp ./ReactKonvaCore.d.ts ./es",
+    "build-cjs": "nwb --config ./nwb.config.cjs.js build-react-component",
+    "build-es": "nwb --config ./nwb.config.es.js build-react-component",
+    "build-libs": "npm run build-cjs && mv lib lib.back && npm run build-es && mv lib.back lib",
     "clean": "nwb clean-module && nwb clean-demo",
     "start": "nwb serve-react-demo",
     "test": "nwb test-react && npm run test:typings",


### PR DESCRIPTION
We are using React-Konva and we encountered some issues on NodeJS unit tests under Jest. 

The current CommonJS build uses imports in the following way:

`require('konva/lib/Core)`

Which Node fails because konva/lib/Core is an ES6 module and you cannot 'require' an ES6 module.

This PR splits the nwb build configuration in two files: one for ES and another for CommonJS.
The CommonJS one includes a Babel plugin that replaces those imports to konva/cmj which is where Konva hosts their CommonJS build.

I'm not sure if this is the best way, I'm not familiar with nwb.

This may fix: #655 