### PR TITLE
Fix node props

### DIFF
--- a/ReactKonvaCore.d.ts
+++ b/ReactKonvaCore.d.ts
@@ -60,8 +60,8 @@ export interface StageProps
 export var Stage: KonvaNodeComponent<Konva.Stage, StageProps>;
 export var Layer: KonvaNodeComponent<Konva.Layer, Konva.LayerConfig>;
 export var FastLayer: KonvaNodeComponent<Konva.FastLayer, Konva.LayerConfig>;
-export var Group: KonvaNodeComponent<Konva.Group>;
-export var Label: KonvaNodeComponent<Konva.Label>;
+export var Group: KonvaNodeComponent<Konva.Group, Konva.ContainerConfig>;
+export var Label: KonvaNodeComponent<Konva.Label, Konva.LabelConfig>;
 
 /** Shapes */
 export var Rect: KonvaNodeComponent<Konva.Rect, Konva.RectConfig>;

--- a/ReactKonvaCore.d.ts
+++ b/ReactKonvaCore.d.ts
@@ -60,7 +60,7 @@ export interface StageProps
 export var Stage: KonvaNodeComponent<Konva.Stage, StageProps>;
 export var Layer: KonvaNodeComponent<Konva.Layer, Konva.LayerConfig>;
 export var FastLayer: KonvaNodeComponent<Konva.FastLayer, Konva.LayerConfig>;
-export var Group: KonvaNodeComponent<Konva.Group, Konva.ContainerConfig>;
+export var Group: KonvaNodeComponent<Konva.Group, Konva.GroupConfig>;
 export var Label: KonvaNodeComponent<Konva.Label, Konva.LabelConfig>;
 
 /** Shapes */


### PR DESCRIPTION
The `Group` type does not expose the correct set of props.
The konva class inherits from `Container` but the props derive from `NodeConfig`.
Meaning the props for `Container`, e.g. those related to cropping, are missing.

As a result IDEs do not type-hint the relevant properties and tooling may even produce warnings / errors about illegal props getting passed.

The first commit notes the correct type for the Group and Label exports.

The second commit the Group-specific config type from https://github.com/konvajs/konva/pull/1337 instead.

