### PR TITLE
Add type definitions of pointer event handlers

### DIFF
--- a/ReactKonvaCore.d.ts
+++ b/ReactKonvaCore.d.ts
@@ -26,6 +26,18 @@ export interface KonvaNodeEvents {
   onTransformStart?(evt: Konva.KonvaEventObject<Event>): void;
   onTransformEnd?(evt: Konva.KonvaEventObject<Event>): void;
   onContextMenu?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onPointerDown?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onPointerMove?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onPointerUp?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onPointerCancel?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onPointerEnter?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onPointerLeave?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onPointerOver?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onPointerOut?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onPointerClick?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onPointerDblClick?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onGotPointerCapture?(evt: Konva.KonvaEventObject<PointerEvent>): void;
+  onLostPointerCapture?(evt: Konva.KonvaEventObject<PointerEvent>): void;
 }
 
 export interface KonvaNodeComponent<

--- a/src/makeUpdates.ts
+++ b/src/makeUpdates.ts
@@ -60,7 +60,7 @@ export function applyNodeProps(instance, props, oldProps = EMPTY_PROPS) {
     var isEvent = key.slice(0, 2) === 'on';
     var propChanged = oldProps[key] !== props[key];
 
-    // if that is a changed event, we need to remvoe it
+    // if that is a changed event, we need to remove it
     if (isEvent && propChanged) {
       var eventName = key.substr(2).toLowerCase();
       if (eventName.substr(0, 7) === 'content') {


### PR DESCRIPTION
This PR adds type definitions of event handler props for pointer events:

- `onPointerDown`
- `onPointerMove`
- `onPointerUp`
- `onPointerCancel`
- `onPointerEnter`
- `onPointerLeave`
- `onPointerOver`
- `onPointerOut`
- `onPointerClick`
- `onPointerDblClick`
- `onGotPointerCapture`
- `onLostPointerCapture`

I checked most of them against Konva 8.4.0. However, I could not verify if the following events work properly:

- `pointercancel`: Could not trigger this at all.
- `gotpointercapture`: Works for shapes, but not `Stage`
- `lostpointercapture`: Works for shapes, but not `Stage`

Though I believe that they can be fired in the right circumstances.

Resolves #717