### PR TITLE
Add ESM and CommonJS entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
   "bugs": "https://github.com/konvajs/react-konva/issues",
   "main": "lib/ReactKonva.js",
   "module": "es/ReactKonva.js",
+  "exports": {
+    ".": {
+      "import": "es/ReactKonva.js",
+      "require": "lib/ReactKonva.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:konvajs/react-konva.git"


### PR DESCRIPTION
Add ESM and CommonJS entry points. Fixes [#714](https://github.com/konvajs/react-konva/issues/714#issuecomment-1506207763).

Docs: [TypeScript](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) & [NodeJS](https://nodejs.org/api/packages.html#conditional-exports)