### PR TITLE
fix: add extensions for relative imports

### DIFF
--- a/src/ReactKonva.ts
+++ b/src/ReactKonva.ts
@@ -8,4 +8,4 @@
 'use strict';
 
 import 'konva';
-export * from './ReactKonvaCore';
+export * from './ReactKonvaCore.js';

--- a/src/ReactKonvaCore.tsx
+++ b/src/ReactKonvaCore.tsx
@@ -8,11 +8,11 @@
 'use strict';
 
 import React from 'react';
-import Konva from 'konva/lib/Core';
+import Konva from 'konva/lib/Core.js';
 import ReactFiberReconciler from 'react-reconciler';
-import { LegacyRoot, ConcurrentRoot } from 'react-reconciler/constants';
-import * as HostConfig from './ReactKonvaHostConfig';
-import { applyNodeProps, toggleStrictMode } from './makeUpdates';
+import { LegacyRoot, ConcurrentRoot } from 'react-reconciler/constants.js';
+import * as HostConfig from './ReactKonvaHostConfig.js';
+import { applyNodeProps, toggleStrictMode } from './makeUpdates.js';
 import { useContextBridge, FiberProvider } from 'its-fine';
 
 function usePrevious(value) {

--- a/src/ReactKonvaHostConfig.ts
+++ b/src/ReactKonvaHostConfig.ts
@@ -1,12 +1,12 @@
-import Konva from 'konva/lib/Core';
-import { applyNodeProps, updatePicture, EVENTS_NAMESPACE } from './makeUpdates';
+import Konva from 'konva/lib/Core.js';
+import { applyNodeProps, updatePicture, EVENTS_NAMESPACE } from './makeUpdates.js';
 
 export {
   unstable_now as now,
   unstable_IdlePriority as idlePriority,
   unstable_runWithPriority as run,
 } from 'scheduler';
-import { DefaultEventPriority } from 'react-reconciler/constants';
+import { DefaultEventPriority } from 'react-reconciler/constants.js';
 
 const NO_CONTEXT = {};
 const UPDATE_SIGNAL = {};

--- a/src/makeUpdates.ts
+++ b/src/makeUpdates.ts
@@ -1,4 +1,4 @@
-import { Konva } from 'konva/lib/Global';
+import { Konva } from 'konva/lib/Global.js';
 
 const propsToSkip = {
   children: true,


### PR DESCRIPTION
This adds `.js` extensions to relative imports to help development in pure ESM browser environments.

Documentation on this can be found [here](https://www.typescriptlang.org/docs/handbook/esm-node.html).

With this line:

> relative import paths need full extensions (e.g we have to write import "./foo.js" instead of import "./foo")