### PR TITLE
React 19 Upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test-build
 .parcel-cache
 dist
 package-lock.json
+.vscode

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "license": "MIT",
   "name": "react-konva",
   "description": "React binding to canvas element via Konva framework",
-  "version": "18.2.10",
+  "version": "19.0.0",
   "keywords": [
     "react",
     "canvas",
@@ -18,9 +18,9 @@
   },
   "dependencies": {
     "@types/react-reconciler": "^0.28.2",
-    "its-fine": "^1.1.1",
-    "react-reconciler": "~0.29.0",
-    "scheduler": "^0.23.0"
+    "its-fine": "^1.2.5",
+    "react-reconciler": "0.31.0-beta-73bcdfbae5-20240502",
+    "scheduler": "0.25.0-beta-73bcdfbae5-20240502"
   },
   "targets": {
     "none": {}
@@ -41,8 +41,8 @@
   ],
   "peerDependencies": {
     "konva": "^8.0.1 || ^7.2.5 || ^9.0.0",
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react": ">=19.0.0-beta",
+    "react-dom": ">=19.0.0-beta"
   },
   "devDependencies": {
     "@types/chai": "^4.3.5",
@@ -53,8 +53,8 @@
     "mocha-headless-chrome": "^4.0.0",
     "parcel": "^2.9.1",
     "process": "^0.11.10",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "19.0.0-beta-73bcdfbae5-20240502",
+    "react-dom": "19.0.0-beta-73bcdfbae5-20240502",
     "sinon": "^15.1.0",
     "timers-browserify": "^2.0.12",
     "typescript": "^5.1.3",
@@ -67,9 +67,9 @@
     "preversion": "npm test",
     "version": "npm run build",
     "postversion": "",
-    "test": "npm run test:build && mocha-headless-chrome -f ./test-build/unit-tests.html -a disable-web-security && npm run test:typings",
-    "test:build": "parcel build ./test/unit-tests.html --dist-dir test-build --target none --public-url ./ --no-source-maps",
-    "test:watch": "rm -rf ./parcel-cache && parcel serve ./test/unit-tests.html"
+    "test": "NODE_ENV=test npm run test:build && mocha-headless-chrome -f ./test-build/unit-tests.html -a disable-web-security && npm run test:typings",
+    "test:build": "NODE_ENV=test parcel build ./test/unit-tests.html --dist-dir test-build --target none --public-url ./ --no-source-maps",
+    "test:watch": "NODE_ENV=test rm -rf ./parcel-cache && parcel serve ./test/unit-tests.html"
   },
   "typings": "react-konva.d.ts",
   "files": [

--- a/src/ReactKonvaCore.tsx
+++ b/src/ReactKonvaCore.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import Konva from 'konva/lib/Core.js';
 import ReactFiberReconciler from 'react-reconciler';
-import { LegacyRoot, ConcurrentRoot } from 'react-reconciler/constants.js';
+import { LegacyRoot } from 'react-reconciler/constants.js';
 import * as HostConfig from './ReactKonvaHostConfig.js';
 import { applyNodeProps, toggleStrictMode } from './makeUpdates.js';
 import { useContextBridge, FiberProvider } from 'its-fine';

--- a/src/ReactKonvaHostConfig.ts
+++ b/src/ReactKonvaHostConfig.ts
@@ -1,18 +1,27 @@
 import Konva from 'konva/lib/Core.js';
-import { applyNodeProps, updatePicture, EVENTS_NAMESPACE } from './makeUpdates.js';
+import {
+  applyNodeProps,
+  updatePicture,
+  EVENTS_NAMESPACE,
+} from './makeUpdates.js';
 
 export {
   unstable_now as now,
   unstable_IdlePriority as idlePriority,
   unstable_runWithPriority as run,
 } from 'scheduler';
-import { DefaultEventPriority } from 'react-reconciler/constants.js';
+import {
+  NoEventPriority,
+  DefaultEventPriority,
+} from 'react-reconciler/constants.js';
 
 const NO_CONTEXT = {};
 const UPDATE_SIGNAL = {};
 
 // for react-spring capability
 (Konva.Node.prototype as any)._applyProps = applyNodeProps;
+
+let currentUpdatePriority: number = NoEventPriority;
 
 export function appendInitialChild(parentInstance, child) {
   if (typeof child === 'string') {
@@ -184,7 +193,6 @@ export function commitMount(instance, type, newProps) {
 
 export function commitUpdate(
   instance,
-  updatePayload,
   type,
   oldProps,
   newProps
@@ -217,4 +225,50 @@ export function clearContainer(container) {
 
 export function detachDeletedInstance() {}
 
-export const getCurrentEventPriority = () => DefaultEventPriority;
+export function getCurrentEventPriority() {
+  return currentUpdatePriority;
+}
+
+export function prepareScopeUpdate() {}
+
+export function getInstanceFromScope() {
+  return null;
+}
+
+export function setCurrentUpdatePriority(newPriority) {
+  currentUpdatePriority = newPriority;
+}
+
+export function getCurrentUpdatePriority() {
+  return currentUpdatePriority;
+}
+
+export function resolveUpdatePriority() {
+  return currentUpdatePriority || DefaultEventPriority;
+}
+
+export function shouldAttemptEagerTransition() {
+  return false;
+}
+
+export function requestPostPaintCallback() {}
+
+export function maySuspendCommit() {
+  return false;
+}
+
+export function preloadInstance() {
+  return true;
+}
+
+export function startSuspendingCommit() {}
+
+export function suspendInstance() {}
+
+export function waitForCommitToBeReady() {
+  return null;
+}
+
+export const NotPendingTransition = null;
+
+export function resetFormInstance() {}


### PR DESCRIPTION
As described in https://github.com/konvajs/react-konva/issues/799, React 19 has some breaking changes that will require updates from third-party rendering libraries. I needed to get a new build of react-konva with React 19 working and I wanted to publish the updates here to share the required changes. Hopefully for a new release to go with React 19!

Changes in this PR
- Upgrade its-fine
- Add new reconciler methods to host config
- Update signature of `commitUpdate`
- Use React.act instead of timeouts in tests